### PR TITLE
stick to runtime v1 deps

### DIFF
--- a/templates/api-to-lambda/{{cookiecutter.__project_name}}/Package.swift
+++ b/templates/api-to-lambda/{{cookiecutter.__project_name}}/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
         .executable(name: "HelloWorld", targets: ["HelloWorld"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", branch: "1.0.0-alpha.3"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", from: "0.4.0"),
         // Uncomment the following line to use the AWS SDK for Swift in your Lambda function aswell as the line in the targets section
         // .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "{{ cookiecutter._aws_swift_sdk_version }}")
     ],

--- a/templates/openapi-to-lambda/{{cookiecutter.__project_name}}/Package.swift
+++ b/templates/openapi-to-lambda/{{cookiecutter.__project_name}}/Package.swift
@@ -29,8 +29,8 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-openapi-generator.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-openapi-runtime.git", from: "1.0.0"),
-    .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.1"),
-    .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "0.2.0"),
+    .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha.3"),
+    .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "0.4.0"),
     .package(url: "https://github.com/swift-server/swift-openapi-lambda.git", from: "0.1.1") 
   ],
   targets: [

--- a/templates/s3-to-lambda/{{cookiecutter.__project_name}}/Package.swift
+++ b/templates/s3-to-lambda/{{cookiecutter.__project_name}}/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
         .executable(name: "S3ToLambdaFunction", targets: ["S3ToLambdaFunction"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", branch: "1.0.0-alpha.3"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", from: "0.4.0"),
         // Uncomment the following line to use the AWS SDK for Swift in your Lambda function aswell as the line in the targets section
         // .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "{{ cookiecutter._aws_swift_sdk_version }}")
     ],

--- a/templates/scheduler-to-lambda/{{cookiecutter.__project_name}}/Package.swift
+++ b/templates/scheduler-to-lambda/{{cookiecutter.__project_name}}/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
         .executable(name: "ScheduledTaskHandler", targets: ["ScheduledTaskHandler"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", branch: "1.0.0-alpha.3"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", from: "0.4.0"),
         // Uncomment the following line to use the AWS SDK for Swift in your Lambda function aswell as the line in the targets section
         // .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "{{ cookiecutter._aws_swift_sdk_version }}")
     ],

--- a/templates/sqs-to-lambda/{{cookiecutter.__project_name}}/Package.swift
+++ b/templates/sqs-to-lambda/{{cookiecutter.__project_name}}/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
         .executable(name: "SQSQueueListener", targets: ["SQSQueueListener"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", branch: "main"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", branch: "1.0.0-alpha.3"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", from: "0.4.0"),
         // Uncomment the following line to use the AWS SDK for Swift in your Lambda function aswell as the line in the targets section
         // .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "{{ cookiecutter._aws_swift_sdk_version }}")
     ],


### PR DESCRIPTION
Swift Runtime for AWS Lambda evolves to v2 and there are some breaking changes on the API.
On the long term, we will rewrite these templates to also support runtime v2.

for the moment, I just force the dependency to use runtime v1